### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -145,7 +145,7 @@ export class FileSystemUtils {
             await walk(fullPath);
           } else if (patterns.some(pattern => {
             if (pattern.includes('*')) {
-              const regex = new RegExp(pattern.replace('*', '.*'));
+              const regex = new RegExp(pattern.replace(/\*/g, '.*'));
               return regex.test(entry.name);
             }
             return entry.name === pattern;


### PR DESCRIPTION
Potential fix for [https://github.com/SpongeBUG/DEB/security/code-scanning/1](https://github.com/SpongeBUG/DEB/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of the asterisk (`*`) in the `pattern` are replaced with `.*` to correctly form the regex pattern. This can be achieved by using a regular expression with the global flag (`g`) in the `replace` method.

- Modify the `replace` method on line 148 to use a regular expression with the global flag.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
